### PR TITLE
lr-theodore: Update LICENSE file path

### DIFF
--- a/scriptmodules/libretrocores/lr-theodore.sh
+++ b/scriptmodules/libretrocores/lr-theodore.sh
@@ -12,7 +12,7 @@
 rp_module_id="lr-theodore"
 rp_module_desc="Thomson MO/TO system emulator"
 rp_module_help="ROM Extensions: *.fd, *.sap, *.k7, *.m5, *.m7, *.rom\n\nAdd your game files in $romdir/moto"
-rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/theodore/master/LICENSE"
+rp_module_licence="GPL3 https://raw.githubusercontent.com/Zlika/theodore/master/LICENSE"
 rp_module_repo="git https://github.com/Zlika/theodore master"
 rp_module_section="exp"
 rp_module_flags=""


### PR DESCRIPTION
The current LICENSE path points to the old libretro clone of the upstream repository. The libretro clone does not exist anymore, the upstream repository must be used instead.